### PR TITLE
Create issue and ping matrix room when latest matrix-sdk code breaks the build

### DIFF
--- a/.github/latest_matrix_sdk_failed_issue_template.md
+++ b/.github/latest_matrix_sdk_failed_issue_template.md
@@ -1,6 +1,11 @@
 ---
 title: Building matrix-rust-sdk-crypto-wasm against the latest matrix-sdk Rust is failing
 ---
-See https://github.com/{{env.GITHUB_REPOSITORY}}/actions/runs/{{env.GITHUB_RUN_ID}}
+Something changed in
+[matrix-rust-sdk](https://github.com/matrix-org/matrix-rust-sdk)'s crypto crate
+that will break the build of this repo (matrix-rust-sdk-crypto-wasm) when we
+update to it.
 
-Latest failure: {{ date | date('dddd, YYYY-MM-DD HH:mm Z') }}
+See the crypto crate's
+[CHANGELOG](https://github.com/matrix-org/matrix-rust-sdk/blob/main/crates/matrix-sdk-crypto/CHANGELOG.md)
+for possible hints about what changed and how to fix it.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
+        # Keep this in sync with:
+        # .github/workflows/latest-matrix-sdk-crypto.yml
+        # .github/workflows/release.yml
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/latest-matrix-sdk-crypto.yml
+++ b/.github/workflows/latest-matrix-sdk-crypto.yml
@@ -81,7 +81,7 @@ jobs:
         if: failure()
         uses: fjogeleit/http-request-action@v1
         with:
-          url: 'https://element.ems.host/hookshot/webhook/4bbf3b21-e94a-4a97-8a09-c0e03a6de173'
+          url: ${{ secrets.CRYPTO_HOOK_URL }}
           method: 'POST'
           customHeaders: '{"Content-Type": "application/json"}'
           data: '{"text": "matrix-rust-sdk-crypto-wasm is failing to build against the latest matrix-sdk Rust code. See ${{ steps.create-issue.outputs.url }}"}'

--- a/.github/workflows/latest-matrix-sdk-crypto.yml
+++ b/.github/workflows/latest-matrix-sdk-crypto.yml
@@ -1,8 +1,24 @@
 name: Build against latest matrix-sdk-crypto
 
+# Runs a nightly job that builds this project against the latest version of
+# matrix-sdk-crypto to find out whether some changes there have modified
+# interfaces we are relying on.
+#
+# It does this by effectively doing:
+#
+#     cargo update matrix-sdk-crypto
+#     yarn build
+#
+# If the build fails, this action:
+#
+# * creates an issue in this project's repo (or updates an existing open issue)
+# * adds a comment to the issue linking to the specific build failure
+# * sends a message to the Crypto team's Matrix room
+
 on:
   workflow_dispatch:
   schedule:
+    # Run this task every day at 01:22 UTC
     - cron:  '22 1 * * *'
 
 concurrency:
@@ -41,6 +57,9 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
+          # Keep this in sync with:
+          # .github/workflows/ci.yml
+          # .github/workflows/release.yml
           node-version: 20.0
 
       - name: Install yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           targets: wasm32-unknown-unknown
 
+        # Keep this in sync with:
+        # .github/workflows/ci.yml
+        # .github/workflows/latest-matrix-sdk-crypto.yml
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
Please use this PR to review not just this commit, but the last few, which I pushed directly because the debugging process for github actions is awful.

You can see a proper diff in this fake PR: https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/154

It's just 2 files:

* https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/blob/andybalaam/create-issue-and-matrix-ping-on-failure/.github/latest_matrix_sdk_failed_issue_template.md and
* https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/blob/andybalaam/create-issue-and-matrix-ping-on-failure/.github/workflows/latest-matrix-sdk-crypto.yml

Thanks!

Fixes https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/issues/135