### PR TITLE
Fix nightly github workflow to build against latest matrix-sdk

### DIFF
--- a/.github/workflows/latest-matrix-sdk-crypto.yml
+++ b/.github/workflows/latest-matrix-sdk-crypto.yml
@@ -52,7 +52,17 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Update to the latest matrix-sdk-crypto version
-        run: cargo update matrix-sdk-crypto
+        run: |
+           tee >> .cargo/config.toml << EOF
+           [patch.crates-io]
+           matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+           matrix-sdk-crypto = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+           matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+           matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+           matrix-sdk-store-encryption = { git = "https://github.com/matrix-org/matrix-rust-sdk" }
+           EOF
+
+           cargo update matrix-sdk-crypto
 
       - name: Install Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
We need to make sure we're not pinned to a release before attempting to upgrade.