### PR TITLE
Bump SDK to eeaa091

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED
 
--   Update matrix-rusk-sdk to `59ecb1edb`.
+-   Update matrix-rusk-sdk to `eeaa091`.
 
 -   **BREAKING**: `OlmMachine.receiveSyncChanges` now returns a list of
     `ProcessedToDeviceEvent` instead of a JSON-encoded list of JSON-encoded events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # UNRELEASED
 
+-   Update matrix-rusk-sdk to `59ecb1edb`.
+
+-   **BREAKING**: `OlmMachine.receiveSyncChanges` now returns a list of
+    `ProcessedToDeviceEvent` instead of a JSON-encoded list of JSON-encoded events.
+    This allows making the difference between an event that was sent in clear and
+    the same event successfully decrypted.
+    ([#236](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/236))
+
 # matrix-sdk-crypto-wasm v14.2.1
 
 Update matrix-sdk-crypto to `0.11.1`, which includes:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,8 +1113,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75aa988a96e4a85e2b854f4f6487d31f1833e8abf3eebc1b8c13274a68dacf45"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
 dependencies = [
  "async-trait",
  "eyeball-im",
@@ -1136,9 +1135,8 @@ dependencies = [
 
 [[package]]
 name = "matrix-sdk-crypto"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5af2cba80b6e9a3a3b2a66734cb400625b9666b3eb0cd7f7b13eede8d3e075a"
+version = "0.11.0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1206,8 +1204,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63da8893fc9062f4b7874f766fd5dcf048f8ea456b08ba89320cc68926b1112e"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1235,8 +1232,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fc0b2a90a9c986d53fb772e49ec1f135748e2b4a7d38b253ee45f97ecb818e"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1248,8 +1244,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b14e1db0b31db81c5d20c20d24c84421893491da30e8e0218e991c3a350188e"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
 dependencies = [
  "base64",
  "blake3",
@@ -1640,9 +1635,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fdaae631940eda62844a8a3026aba2ba84c22588c888ebec44861ba4d0c18"
+checksum = "d910a9b75cbf0e88f74295997c1a41c3ab7a117879a029c72db815192c167a0d"
 dependencies = [
  "assign",
  "js_int",
@@ -1655,9 +1650,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.20.2"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9a89ac03a0f4451f946ed9aed6fdd16ef5a78a3a2849e87af4b2474a176b2fb"
+checksum = "09cc4ff88a70a3d1e7a2c5b51cca7499cb889b42687608ab664b9a216c49314d"
 dependencies = [
  "as_variant",
  "assign",
@@ -1712,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.30.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c100eb6c7691ef010f18d9af315f486fc4da621b7203c431e88352148e84551"
+checksum = "41ab3d1b54c32a65194ecc44bc7f7575df50ef4255b139547d7dcc1753dc883d"
 dependencies = [
  "as_variant",
  "indexmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa091#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "async-trait",
  "eyeball-im",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa091#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa091#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa091#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa091#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "base64",
  "blake3",
@@ -1635,9 +1635,8 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d910a9b75cbf0e88f74295997c1a41c3ab7a117879a029c72db815192c167a0d"
+version = "0.12.2"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "assign",
  "js_int",
@@ -1650,9 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc4ff88a70a3d1e7a2c5b51cca7499cb889b42687608ab664b9a216c49314d"
+version = "0.20.2"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "assign",
@@ -1675,8 +1673,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b75da013b362664c3e161662902e5da3f77e990525681b59c6035bac27e87b4"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "base64",
@@ -1707,9 +1704,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ab3d1b54c32a65194ecc44bc7f7575df50ef4255b139547d7dcc1753dc883d"
+version = "0.30.2"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1732,8 +1728,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "js_int",
  "thiserror 2.0.12",
@@ -1742,8 +1737,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1182e83ee5cd10121974f163337b16af68a93eedfc7cdbdbd52307ac7e1d743"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { version = "0.11.0", features = ["js"] }
-matrix-sdk-indexeddb = { version = "0.11.0", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { version = "0.11.0", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -83,7 +83,8 @@ wasm-bindgen-test = "0.3.37"
 vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
-version = "0.11.0"
+git = "https://github.com/matrix-org/matrix-rust-sdk"
+rev = "59ecb1edb"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa091", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa091", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa091", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -84,7 +84,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "59ecb1edb"
+rev = "eeaa091"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,13 @@ declare module "./pkg/matrix_sdk_crypto_wasm.js" {
         | RoomMessageRequest
         | KeysBackupRequest;
 
+    /** The types returned by {@link OlmMachine.receiveSyncChanges}. */
+    type ProcessedToDeviceEvent =
+        | DecryptedToDeviceEvent
+        | PlainTextToDeviceEvent
+        | InvalidToDeviceEvent
+        | UTDToDeviceEvent;
+
     interface OlmMachine {
         trackedUsers(): Promise<Set<UserId>>;
         updateTrackedUsers(users: UserId[]): Promise<void>;
@@ -69,7 +76,7 @@ declare module "./pkg/matrix_sdk_crypto_wasm.js" {
             changed_devices: DeviceLists,
             one_time_keys_counts: Map<string, number>,
             unused_fallback_keys?: Set<string> | null,
-        ): Promise<string>;
+        ): Promise<Array<ProcessedToDeviceEvent>>;
         outgoingRequests(): Promise<Array<OutgoingRequest>>;
         markRequestAsSent(request_id: string, request_type: RequestType, response: string): Promise<boolean>;
         encryptRoomEvent(room_id: RoomId, event_type: string, content: string): Promise<string>;

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -513,7 +513,7 @@ pub fn outgoing_request_to_js_value(
         }
 
         AnyOutgoingRequest::RoomMessage(request) => {
-            JsValue::from(RoomMessageRequest::try_from((request_id, request))?)
+            JsValue::from(RoomMessageRequest::try_from((request_id, request.as_ref()))?)
         }
     })
 }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -104,10 +104,10 @@ impl TryFrom<Verification> for JsValue {
         use matrix_sdk_crypto::Verification::*;
 
         Ok(match verification.0 {
-            SasV1(sas) => JsValue::from(Sas { inner: sas }),
+            SasV1(sas) => JsValue::from(Sas { inner: *sas }),
 
             #[cfg(feature = "qrcode")]
-            QrV1(qr) => JsValue::from(Qr { inner: qr }),
+            QrV1(qr) => JsValue::from(Qr { inner: *qr }),
 
             _ => {
                 return Err(JsError::new(
@@ -1094,7 +1094,7 @@ impl TryFrom<OutgoingVerificationRequest> for JsValue {
             }
 
             InRoom(request) => {
-                JsValue::from(requests::RoomMessageRequest::try_from((request_id, &request))?)
+                JsValue::from(requests::RoomMessageRequest::try_from((request_id, request.as_ref()))?)
             }
         })
     }

--- a/tests/helper.js
+++ b/tests/helper.js
@@ -16,10 +16,12 @@ async function addMachineToMachine(machineToAdd, machine) {
     const oneTimeKeyCounts = new Map();
     const unusedFallbackKeys = new Set();
 
-    const receiveSyncChanges = JSON.parse(
-        await machineToAdd.receiveSyncChanges(toDeviceEvents, changedDevices, oneTimeKeyCounts, unusedFallbackKeys),
+    const receiveSyncChanges = await machineToAdd.receiveSyncChanges(
+        toDeviceEvents,
+        changedDevices,
+        oneTimeKeyCounts,
+        unusedFallbackKeys,
     );
-
     expect(receiveSyncChanges).toEqual([]);
 
     const outgoingRequests = await machineToAdd.outgoingRequests();


### PR DESCRIPTION
This includes https://github.com/matrix-org/matrix-rust-sdk/pull/5048. The significant changes for us are that `AnyOutgoingRequest::RoomMessage`, `OutgoingVerificationRequest::InRoom`, `Verification::SasV1` and `Verification::QrV1` are all now `Box`es that we need to deref.

Based on https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/236.

This is the second of several PRs that I am pulling out of #226.