### PR TITLE
Bump sdk to 022068996

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # UNRELEASED
 
--   Update matrix-rusk-sdk to `59ecb1edb`.
+-   Update matrix-rusk-sdk to `eeaa09102`, which includes:
+
+    -   Send stable identifier `sender_device_keys` for MSC4147 (Including device
+        keys with Olm-encrypted events).
+        ([#4964](https://github.com/matrix-org/matrix-rust-sdk/pull/4964))
+
+    -   Fix bug which caused room keys to be unnecessarily rotated on every send in the
+        presence of blacklisted/withheld devices in the room.
+        ([#4954](https://github.com/matrix-org/matrix-rust-sdk/pull/4954))
+
+    -   Fix [#2729](https://github.com/matrix-org/matrix-rust-sdk/issues/2729) which in rare
+        cases can cause room key oversharing.
+        ([#4975](https://github.com/matrix-org/matrix-rust-sdk/pull/4975))
 
 -   **BREAKING**: `OlmMachine.receiveSyncChanges` now returns a list of
     `ProcessedToDeviceEvent` instead of a JSON-encoded list of JSON-encoded events.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED
 
--   Update matrix-rusk-sdk to `eeaa09102`, which includes:
+-   Update matrix-rusk-sdk to `022068996`, which includes:
 
     -   Send stable identifier `sender_device_keys` for MSC4147 (Including device
         keys with Olm-encrypted events).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "async-trait",
  "eyeball-im",
@@ -1136,7 +1136,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1204,7 +1204,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1232,7 +1232,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1244,7 +1244,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=59ecb1edb#59ecb1edbd79dd3bc3dc185c871e9f147c2937bc"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
 dependencies = [
  "base64",
  "blake3",
@@ -1635,9 +1635,8 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d910a9b75cbf0e88f74295997c1a41c3ab7a117879a029c72db815192c167a0d"
+version = "0.12.2"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "assign",
  "js_int",
@@ -1650,9 +1649,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc4ff88a70a3d1e7a2c5b51cca7499cb889b42687608ab664b9a216c49314d"
+version = "0.20.2"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "assign",
@@ -1675,8 +1673,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b75da013b362664c3e161662902e5da3f77e990525681b59c6035bac27e87b4"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "base64",
@@ -1707,9 +1704,8 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ab3d1b54c32a65194ecc44bc7f7575df50ef4255b139547d7dcc1753dc883d"
+version = "0.30.2"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1732,8 +1728,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "js_int",
  "thiserror 2.0.12",
@@ -1742,8 +1737,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1182e83ee5cd10121974f163337b16af68a93eedfc7cdbdbd52307ac7e1d743"
+source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -590,6 +590,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +742,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b7410cae13cbc75623c98ac4cbfd1f0bedddf3227afc24f370cf0f50a44a11c"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "match_token",
 ]
 
 [[package]]
@@ -1029,10 +1051,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "macroific"
@@ -1088,6 +1126,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "markup5ever"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a7213d12e1864c0f002f52c2923d4556935a43dec5e71355c2760e0f6e7a18"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "match_token"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "matrix-pickle"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1113,7 +1176,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
 dependencies = [
  "async-trait",
  "eyeball-im",
@@ -1136,7 +1199,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1204,7 +1267,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1232,7 +1295,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1244,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=eeaa09102#eeaa091024bcd94421882077d88bd1b65fdeecfa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
 dependencies = [
  "base64",
  "blake3",
@@ -1284,6 +1347,12 @@ checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -1347,6 +1416,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1367,6 +1459,58 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1424,6 +1568,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1583,6 +1733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "188bbae3aa4739bd264e9204da5919b2c91dd87dcce5049cf04bdf6aa17c5012"
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1636,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
 dependencies = [
  "assign",
  "js_int",
@@ -1644,13 +1803,14 @@ dependencies = [
  "ruma-client-api",
  "ruma-common",
  "ruma-events",
+ "ruma-html",
  "web-time",
 ]
 
 [[package]]
 name = "ruma-client-api"
 version = "0.20.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
 dependencies = [
  "as_variant",
  "assign",
@@ -1673,7 +1833,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
 dependencies = [
  "as_variant",
  "base64",
@@ -1705,7 +1865,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.2"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1726,9 +1886,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruma-html"
+version = "0.4.0"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+dependencies = [
+ "as_variant",
+ "html5ever",
+ "phf",
+ "tracing",
+ "wildmatch",
+]
+
+[[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
 dependencies = [
  "js_int",
  "thiserror 2.0.12",
@@ -1737,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "git+https://github.com/ruma/ruma?rev=689d9613a985edc089b5b729e6d9362f09b5df4f#689d9613a985edc089b5b729e6d9362f09b5df4f"
+source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",
@@ -1784,6 +1956,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1901,6 +2079,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,6 +2114,31 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -1963,6 +2172,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
 ]
 
 [[package]]
@@ -2269,6 +2489,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa09102", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa09102", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa09102", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "022068996", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "022068996", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "022068996", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -84,7 +84,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "eeaa09102"
+rev = "022068996"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "59ecb1edb", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa09102", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa09102", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "eeaa09102", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -84,7 +84,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "59ecb1edb"
+rev = "eeaa09102"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/src/requests.rs
+++ b/src/requests.rs
@@ -513,7 +513,7 @@ pub fn outgoing_request_to_js_value(
         }
 
         AnyOutgoingRequest::RoomMessage(request) => {
-            JsValue::from(RoomMessageRequest::try_from((request_id, request))?)
+            JsValue::from(RoomMessageRequest::try_from((request_id, request.as_ref()))?)
         }
     })
 }

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -1,5 +1,7 @@
 //! Types related to responses.
 
+use std::sync::Arc;
+
 use js_sys::{Array, JsString};
 pub(crate) use matrix_sdk_common::ruma::api::client::{
     backup::add_backup_keys::v3::Response as KeysBackupResponse,
@@ -18,7 +20,7 @@ use matrix_sdk_common::{
 use matrix_sdk_crypto::types::requests::AnyIncomingResponse;
 use wasm_bindgen::prelude::*;
 
-use crate::{encryption, identifiers, impl_from_to_inner, requests::RequestType};
+use crate::{encryption, identifiers, requests::RequestType};
 
 pub(crate) fn response_from_string(body: &str) -> http::Result<http::Response<Vec<u8>>> {
     http::Response::builder().status(200).body(body.as_bytes().to_vec())
@@ -225,10 +227,8 @@ impl From<matrix_sdk_common::deserialized_responses::TimelineEvent> for Decrypte
 #[wasm_bindgen()]
 #[derive(Debug)]
 pub struct EncryptionInfo {
-    inner: matrix_sdk_common::deserialized_responses::EncryptionInfo,
+    inner: Arc<matrix_sdk_common::deserialized_responses::EncryptionInfo>,
 }
-
-impl_from_to_inner!(matrix_sdk_common::deserialized_responses::EncryptionInfo => EncryptionInfo);
 
 #[wasm_bindgen()]
 impl EncryptionInfo {
@@ -288,5 +288,11 @@ impl EncryptionInfo {
             verification_state.to_shield_state_lax()
         }
         .into()
+    }
+}
+
+impl From<Arc<matrix_sdk_common::deserialized_responses::EncryptionInfo>> for EncryptionInfo {
+    fn from(value: Arc<matrix_sdk_common::deserialized_responses::EncryptionInfo>) -> Self {
+        Self { inner: value }
     }
 }

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -104,10 +104,10 @@ impl TryFrom<Verification> for JsValue {
         use matrix_sdk_crypto::Verification::*;
 
         Ok(match verification.0 {
-            SasV1(sas) => JsValue::from(Sas { inner: sas }),
+            SasV1(sas) => JsValue::from(Sas { inner: *sas }),
 
             #[cfg(feature = "qrcode")]
-            QrV1(qr) => JsValue::from(Qr { inner: qr }),
+            QrV1(qr) => JsValue::from(Qr { inner: *qr }),
 
             _ => {
                 return Err(JsError::new(
@@ -1093,9 +1093,10 @@ impl TryFrom<OutgoingVerificationRequest> for JsValue {
                 JsValue::from(requests::ToDeviceRequest::try_from((request_id, &request))?)
             }
 
-            InRoom(request) => {
-                JsValue::from(requests::RoomMessageRequest::try_from((request_id, &request))?)
-            }
+            InRoom(request) => JsValue::from(requests::RoomMessageRequest::try_from((
+                request_id,
+                request.as_ref(),
+            ))?),
         })
     }
 }


### PR DESCRIPTION
Update the wasm bindings as far as https://github.com/matrix-org/matrix-rust-sdk/commit/022068996.

The breaking changes here are https://github.com/matrix-org/matrix-rust-sdk/pull/5048 and https://github.com/matrix-org/matrix-rust-sdk/pull/5134, which wrap things in `Box` or `Arc`. Review commit-by-commit.

The second of several PRs that I am pulling out of #226.