### PR TITLE
Expose EncryptionInfo on decrypted to-device events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED
 
--   Update matrix-rusk-sdk to `022068996`, which includes:
+-   Update matrix-rusk-sdk to `0f73ffde6`, which includes:
 
     -   Send stable identifier `sender_device_keys` for MSC4147 (Including device
         keys with Olm-encrypted events).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1176,9 +1176,8 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0f73ffde6#0f73ffde689fe07e8989068ecc59b140694ae5ed"
 dependencies = [
- "async-trait",
  "eyeball-im",
  "futures-core",
  "futures-util",
@@ -1199,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0f73ffde6#0f73ffde689fe07e8989068ecc59b140694ae5ed"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1267,7 +1266,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0f73ffde6#0f73ffde689fe07e8989068ecc59b140694ae5ed"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1295,7 +1294,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0f73ffde6#0f73ffde689fe07e8989068ecc59b140694ae5ed"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1307,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.11.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=022068996#0220689964fbecf2e3d293ddd03a4775df874dc1"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0f73ffde6#0f73ffde689fe07e8989068ecc59b140694ae5ed"
 dependencies = [
  "base64",
  "blake3",
@@ -1794,8 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "ruma"
-version = "0.12.2"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d910a9b75cbf0e88f74295997c1a41c3ab7a117879a029c72db815192c167a0d"
 dependencies = [
  "assign",
  "js_int",
@@ -1809,8 +1809,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-client-api"
-version = "0.20.2"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc4ff88a70a3d1e7a2c5b51cca7499cb889b42687608ab664b9a216c49314d"
 dependencies = [
  "as_variant",
  "assign",
@@ -1833,7 +1834,8 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b75da013b362664c3e161662902e5da3f77e990525681b59c6035bac27e87b4"
 dependencies = [
  "as_variant",
  "base64",
@@ -1864,8 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-events"
-version = "0.30.2"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+version = "0.30.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41ab3d1b54c32a65194ecc44bc7f7575df50ef4255b139547d7dcc1753dc883d"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1887,8 +1890,9 @@ dependencies = [
 
 [[package]]
 name = "ruma-html"
-version = "0.4.0"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865afa2321e34fa836ea4c1d77ce0c2bb40f7d13fe18ee3e795091fd8d173a1d"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -1900,7 +1904,8 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad674b5e5368c53a2c90fde7dac7e30747004aaf7b1827b72874a25fc06d4d8"
 dependencies = [
  "js_int",
  "thiserror 2.0.12",
@@ -1909,7 +1914,8 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.1"
-source = "git+https://github.com/ruma/ruma?rev=b4941a991919685345646a230b05b985338ec3f8#b4941a991919685345646a230b05b985338ec3f8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1182e83ee5cd10121974f163337b16af68a93eedfc7cdbdbd52307ac7e1d743"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "022068996", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "022068996", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "022068996", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0f73ffde6", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0f73ffde6", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0f73ffde6", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -84,7 +84,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "022068996"
+rev = "0f73ffde6"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -362,7 +362,7 @@ impl OlmMachine {
 
             Ok(processed_to_device_events
                 .into_iter()
-                .map(processed_to_device_event_to_js_value)
+                .filter_map(processed_to_device_event_to_js_value)
                 .collect::<Vec<_>>())
         }))
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -480,7 +480,7 @@ pub fn processed_to_device_event_to_js_value(
     processed_to_device_event: matrix_sdk_crypto::types::ProcessedToDeviceEvent,
 ) -> JsValue {
     match processed_to_device_event {
-        matrix_sdk_crypto::types::ProcessedToDeviceEvent::Decrypted(raw) => {
+        matrix_sdk_crypto::types::ProcessedToDeviceEvent::Decrypted { raw, .. } => {
             DecryptedToDeviceEvent { decrypted_raw_event: raw.json().get().into() }.into()
         }
         matrix_sdk_crypto::types::ProcessedToDeviceEvent::UnableToDecrypt(utd) => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -10,12 +10,14 @@ use matrix_sdk_common::ruma::OwnedRoomId;
 use matrix_sdk_crypto::backups::{
     SignatureState as InnerSignatureState, SignatureVerification as InnerSignatureVerification,
 };
+use tracing::warn;
 use wasm_bindgen::prelude::*;
 
 use crate::{
     encryption::EncryptionAlgorithm,
     identifiers::{DeviceKeyId, UserId},
     impl_from_to_inner,
+    responses::ToDeviceEncryptionInfo,
     vodozemac::Ed25519Signature,
 };
 
@@ -395,6 +397,10 @@ pub struct DecryptedToDeviceEvent {
     /// zeroized).
     #[wasm_bindgen(readonly, getter_with_clone, js_name = "decryptedRawEvent")]
     pub decrypted_raw_event: JsString,
+
+    /// The encryption information for the event.
+    #[wasm_bindgen(readonly, getter_with_clone, js_name = "encryptionInfo")]
+    pub encryption_info: ToDeviceEncryptionInfo,
 }
 
 #[wasm_bindgen]
@@ -473,15 +479,41 @@ impl InvalidToDeviceEvent {
 /// Convert an `ProcessedToDeviceEvent` into a `JsValue`, ready to return to
 /// JavaScript.
 ///
-/// JavaScript has no complex enums like Rust. To return structs of
-/// different types, we have no choice other than hiding everything behind a
-/// `JsValue`.
+/// JavaScript has no complex enums like Rust. To return structs of different
+/// types, we have no choice other than hiding everything behind a `JsValue`.
+///
+/// We attempt to map the event onto one of the following types:
+///  * [`DecryptedToDeviceEvent`]
+///  * [`UTDToDeviceEvent`]
+///  * [`PlainTextToDeviceEvent`]
+///  * [`InvalidToDeviceEvent`].
+///
+/// We then convert that result into a [`JsValue`].
+///
+/// If the event cannot be mapped into one of those types, we instead return
+/// `None`, indicating the event should be discarded.
 pub fn processed_to_device_event_to_js_value(
     processed_to_device_event: matrix_sdk_crypto::types::ProcessedToDeviceEvent,
-) -> JsValue {
-    match processed_to_device_event {
-        matrix_sdk_crypto::types::ProcessedToDeviceEvent::Decrypted { raw, .. } => {
-            DecryptedToDeviceEvent { decrypted_raw_event: raw.json().get().into() }.into()
+) -> Option<JsValue> {
+    let result = match processed_to_device_event {
+        matrix_sdk_crypto::types::ProcessedToDeviceEvent::Decrypted { raw, encryption_info } => {
+            match encryption_info.try_into() {
+                Ok(encryption_info) => DecryptedToDeviceEvent {
+                    decrypted_raw_event: raw.json().get().into(),
+                    encryption_info,
+                }
+                .into(),
+                Err(e) => {
+                    // This can only happen if we receive an encrypted to-device event which is
+                    // encrypted with an algorithm we don't recognise. This
+                    // shouldn't really happen, unless the wasm bindings have
+                    // gotten way out of step with the underlying SDK.
+                    //
+                    // There's not a lot we can do here: we just throw away the event.
+                    warn!("Dropping incoming to-device event with invalid encryption_info: {e:?}");
+                    return None;
+                }
+            }
         }
         matrix_sdk_crypto::types::ProcessedToDeviceEvent::UnableToDecrypt(utd) => {
             UTDToDeviceEvent { wire_event: utd.json().get().into() }.into()
@@ -492,5 +524,6 @@ pub fn processed_to_device_event_to_js_value(
         matrix_sdk_crypto::types::ProcessedToDeviceEvent::Invalid(invalid) => {
             InvalidToDeviceEvent { wire_event: invalid.json().get().into() }.into()
         }
-    }
+    };
+    Some(result)
 }

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -1851,6 +1851,10 @@ describe(OlmMachine.name, () => {
             expect(toDeviceEvent.sender).toEqual("@alice:example.org");
             expect(toDeviceEvent.type).toEqual("custom.type");
             expect(toDeviceEvent.content.foo).toEqual("bar");
+
+            const encryptionInfo = (processed as DecryptedToDeviceEvent).encryptionInfo;
+            expect(encryptionInfo.senderCurve25519Key).toEqual(alice.identityKeys.curve25519.toBase64());
+            expect(encryptionInfo.isSenderVerified()).toBe(false);
         });
     });
 });


### PR DESCRIPTION
Bump SDK to https://github.com/matrix-org/matrix-rust-sdk/commit/0f73ffde, which exposes encryption info on to-device events.

We add a new `ToDeviceEncryptionInfo` struct, which is a member of  `DecryptedToDeviceEvent`.

Review commit-by-commit.

Based on https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/238.

The third of several PRs that I am pulling out of #226.