### PR TITLE
Drop dependency on `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,6 @@ dependencies = [
 name = "matrix-sdk-crypto-wasm"
 version = "0.0.0"
 dependencies = [
- "anyhow",
  "console_error_panic_hook",
  "futures-util",
  "getrandom 0.3.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
+thiserror = "2.0.12"
 tracing = { version = "0.1.36", default-features = false, features = ["std"] }
 tracing-subscriber = { version = "0.3.14", default-features = false, features = ["registry", "std", "ansi"] }
 url = "2.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,6 @@ default = ["qrcode"]
 qrcode = ["matrix-sdk-crypto/qrcode", "dep:matrix-sdk-qrcode"]
 
 [dependencies]
-anyhow = "1.0.68"
 console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
 # getrandom is not a direct dependency, but we need to enable the "wasm_js" backend.

--- a/src/future.rs
+++ b/src/future.rs
@@ -1,18 +1,29 @@
 use std::future::Future;
 
-use futures_util::TryFutureExt;
 use js_sys::Promise;
 use wasm_bindgen::{JsError, JsValue, UnwrapThrowExt};
 use wasm_bindgen_futures::spawn_local;
 
+/**
+ * Convert a Rust [`Future`] which returns [`Result<T, JsError>`] into a
+ * Javascript [`Promise`] which either resolves with an object of type `T`,
+ * or rejects with an error of type [`Error`].
+ *
+ * [`Error`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
+ */
 pub(crate) fn future_to_promise<F, T>(future: F) -> Promise
 where
-    F: Future<Output = Result<T, anyhow::Error>> + 'static,
+    F: Future<Output = Result<T, JsError>> + 'static,
     T: Into<JsValue>,
 {
-    future_to_promise_with_custom_error(future.map_err(|error| JsError::new(&error.to_string())))
+    future_to_promise_with_custom_error(future)
 }
 
+/**
+ * Convert a Rust [`Future`] which returns [`Result<T, E>`] into a
+ * Javascript [`Promise`] which either resolves with an object of type `T`,
+ * or rejects with an error of type `E`.
+ */
 pub(crate) fn future_to_promise_with_custom_error<F, T, E>(future: F) -> Promise
 where
     F: Future<Output = Result<T, E>> + 'static,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -979,7 +979,7 @@ impl OlmMachine {
         let me = self.inner.clone();
 
         future_to_promise(async move {
-            stream_to_json_array(pin!(
+            Ok(stream_to_json_array(pin!(
                 me.store()
                     .export_room_keys_stream(|session| {
                         let session = session.clone();
@@ -992,7 +992,7 @@ impl OlmMachine {
                     })
                     .await?,
             ))
-            .await
+            .await?)
         })
     }
 
@@ -1696,7 +1696,7 @@ pub(crate) async fn promise_result_to_future(
     }
 }
 
-async fn stream_to_json_array<T, S>(mut stream: Pin<&mut S>) -> Result<String, anyhow::Error>
+async fn stream_to_json_array<T, S>(mut stream: Pin<&mut S>) -> Result<String, serde_json::Error>
 where
     T: Serialize,
     S: Stream<Item = T>,
@@ -1709,5 +1709,5 @@ where
     }
     seq.end()?;
 
-    Ok(String::from_utf8(stream_json)?)
+    Ok(String::from_utf8(stream_json).expect("serde_json generated invalid UTF8"))
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -99,9 +99,7 @@ impl OlmMachine {
         let user_id = user_id.inner.clone();
         let device_id = device_id.inner.clone();
 
-        let store_handle = StoreHandle::open(store_name, store_passphrase)
-            .await
-            .map_err(|e| JsError::from(&*e))?;
+        let store_handle = StoreHandle::open(store_name, store_passphrase).await?;
         Self::init_helper(user_id, device_id, store_handle).await
     }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use anyhow::Context;
 use matrix_sdk_crypto::{
     store::{DynCryptoStore, IntoCryptoStore, MemoryStore},
     types::BackupSecrets,
@@ -50,19 +49,19 @@ impl StoreHandle {
         store_name: Option<String>,
         store_passphrase: Option<String>,
     ) -> Result<StoreHandle, JsError> {
-        StoreHandle::open(store_name, store_passphrase).await.map_err(|e| JsError::from(&*e))
+        StoreHandle::open(store_name, store_passphrase).await
     }
 
     pub(crate) async fn open(
         store_name: Option<String>,
         store_passphrase: Option<String>,
-    ) -> Result<StoreHandle, anyhow::Error> {
+    ) -> Result<StoreHandle, JsError> {
         let store = match store_name {
             Some(store_name) => Self::open_indexeddb(&store_name, store_passphrase).await?,
 
             None => {
                 if store_passphrase.is_some() {
-                    return Err(anyhow::Error::msg(
+                    return Err(JsError::new(
                         "The `store_passphrase` has been set, but it has an effect only if \
                         `store_name` is set, which is not; please provide one",
                     ));
@@ -118,8 +117,7 @@ impl StoreHandle {
             store_key
                 .as_slice()
                 .try_into()
-                .with_context(|| "Expected a key of length 32")
-                .map_err(|e| JsError::from(&*e))?,
+                .map_err(|_| JsError::new("Expected a key of length 32"))?,
         );
         store_key.zeroize();
 

--- a/src/verification.rs
+++ b/src/verification.rs
@@ -1034,9 +1034,7 @@ impl VerificationRequest {
                 .transpose()
             {
                 Ok(a) => Ok(a),
-                Err(_) => {
-                    Err(anyhow::Error::msg("Failed to build the outgoing verification request"))
-                }
+                Err(_) => Err(JsError::new("Failed to build the outgoing verification request")),
             }
         })
     }


### PR DESCRIPTION
Preparation for upgrading to matrix-rust-sdk 0.12.0.

As of https://github.com/matrix-org/matrix-rust-sdk/pull/5082, some of the the errors returned by the rust SDK are no longer `Send + Sync`. That means we can no longer pass them into `anyhow::Error::from()`.

As it turns out, most of our uses of `anyhow::Error` are redundant anyway. This patch set (review commit-by-commit) removes the places we use `anyhow::Error`, and means that we will be able to build against rust-sdk 0.12.0.