### PR TITLE
Add `DecryptionErrorCode::MismatchedSender`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # UNRELEASED
 
--   Update matrix-rust-sdk to `0e9ce0271`.
+-   Update matrix-rust-sdk to `6ab11a032`.
+
+-   Add a new error code for `MegolmDecryptionError`, `DecryptionErrorCode::MismatchedSender`, indicating that the sender of the event does not match the owner of the device that established the Megolm session. ([#248](https://github.com/matrix-org/matrix-rust-sdk-crypto-wasm/pull/248))
 
 # matrix-sdk-crypto-wasm v15.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # UNRELEASED
 
+-   Update matrix-rust-sdk to `0e9ce0271`.
+
 # matrix-sdk-crypto-wasm v15.0.0
 
 -   Update matrix-rusk-sdk to `0.12.0`, which includes:
@@ -41,7 +43,8 @@ Update matrix-sdk-crypto to `0.11.1`, which includes:
 
 -   Check the sender of an event matches owner of session, preventing sender
     spoofing by homeserver owners.
-    [13c1d20](https://github.com/matrix-org/matrix-rust-sdk/commit/13c1d2048286bbabf5e7bc6b015aafee98f04d55) (High, [GHSA-x958-rvg6-956w](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-x958-rvg6-956w)).
+    [13c1d20](https://github.com/matrix-org/matrix-rust-sdk/commit/13c1d2048286bbabf5e7bc6b015aafee98f04d55) (
+    High, [GHSA-x958-rvg6-956w](https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-x958-rvg6-956w)).
 
 # matrix-sdk-crypto-wasm v14.2.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,8 +1187,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1029695dcc9f5c343e76a02824d679e32264928e1a202481430add2991b6c0"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -1211,8 +1210,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46a2d75518e77b54d5aa2d0a5f49c4efb534dd580dca07f50e62b74cbbca77b1"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1280,8 +1278,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d3d7f2a4daea5100b45d82d2e62dd2f9e82f69e12af01838104460bd9955b6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1309,8 +1306,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ba86b8f305339c84c5749551e32cdce042de852def1c521ea4b79c6795dafb"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1322,8 +1318,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f6c701ef4ff241dd19fd5d6999f68f86d5438903398f33b1f524da0c3ac99"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,7 +1187,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.12.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=6ab11a032#6ab11a03239933cedfd3d55856ffd9ae8d27eb96"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -1210,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.12.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=6ab11a032#6ab11a03239933cedfd3d55856ffd9ae8d27eb96"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1278,7 +1278,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.12.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=6ab11a032#6ab11a03239933cedfd3d55856ffd9ae8d27eb96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1306,7 +1306,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.12.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=6ab11a032#6ab11a03239933cedfd3d55856ffd9ae8d27eb96"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1318,7 +1318,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.12.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=0e9ce0271#0e9ce0271ef97e7cf6d1b5d5c124b3774f6fe056"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk?rev=6ab11a032#6ab11a03239933cedfd3d55856ffd9ae8d27eb96"
 dependencies = [
  "base64",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { version = "0.12.0", features = ["js"] }
-matrix-sdk-indexeddb = { version = "0.12.0", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { version = "0.12.0", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0e9ce0271", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0e9ce0271", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0e9ce0271", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -83,7 +83,8 @@ wasm-bindgen-test = "0.3.37"
 vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
-version = "0.12.0"
+git = "https://github.com/matrix-org/matrix-rust-sdk"
+rev = "0e9ce0271"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,9 +64,9 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0e9ce0271", features = ["js"] }
-matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0e9ce0271", default-features = false, features = ["e2e-encryption"] }
-matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "0e9ce0271", optional = true }
+matrix-sdk-common = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "6ab11a032", features = ["js"] }
+matrix-sdk-indexeddb = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "6ab11a032", default-features = false, features = ["e2e-encryption"] }
+matrix-sdk-qrcode = { git = "https://github.com/matrix-org/matrix-rust-sdk", rev = "6ab11a032", optional = true }
 serde = "1.0.91"
 serde_json = "1.0.91"
 serde-wasm-bindgen = "0.6.5"
@@ -84,7 +84,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
-rev = "0e9ce0271"
+rev = "6ab11a032"
 default-features = false
 features = ["js", "automatic-room-key-forwarding"]
 

--- a/src/backup.rs
+++ b/src/backup.rs
@@ -10,10 +10,10 @@ use crate::impl_from_to_inner;
 #[derive(Debug, Clone)]
 #[wasm_bindgen]
 pub struct BackupDecryptionKey {
-    pub(crate) inner: store::BackupDecryptionKey,
+    pub(crate) inner: store::types::BackupDecryptionKey,
 }
 
-impl_from_to_inner!(store::BackupDecryptionKey => BackupDecryptionKey);
+impl_from_to_inner!(store::types::BackupDecryptionKey => BackupDecryptionKey);
 
 /// The public part of the backup key.
 #[derive(Debug, Clone)]
@@ -43,7 +43,7 @@ impl BackupDecryptionKey {
     #[wasm_bindgen(js_name = "createRandomKey")]
     pub fn create_random_key() -> BackupDecryptionKey {
         BackupDecryptionKey {
-            inner: store::BackupDecryptionKey::new()
+            inner: store::types::BackupDecryptionKey::new()
                 .expect("Can't gather enough randomness to create a recovery key"),
         }
     }
@@ -51,7 +51,7 @@ impl BackupDecryptionKey {
     /// Try to create a [`BackupDecryptionKey`] from a base 64 encoded string.
     #[wasm_bindgen(js_name = "fromBase64")]
     pub fn from_base64(key: String) -> Result<BackupDecryptionKey, JsError> {
-        Ok(Self { inner: store::BackupDecryptionKey::from_base64(&key)? })
+        Ok(Self { inner: store::types::BackupDecryptionKey::from_base64(&key)? })
     }
 
     /// Convert the backup decryption key to a base 64 encoded string.
@@ -92,8 +92,8 @@ pub struct RoomKeyCounts {
     pub backed_up: f64,
 }
 
-impl From<matrix_sdk_crypto::store::RoomKeyCounts> for RoomKeyCounts {
-    fn from(inner: matrix_sdk_crypto::store::RoomKeyCounts) -> Self {
+impl From<store::types::RoomKeyCounts> for RoomKeyCounts {
+    fn from(inner: store::types::RoomKeyCounts) -> Self {
         RoomKeyCounts {
             // There is no `TryFrom<usize> for f64`, so first downcast the usizes to u32, then back
             // up to f64

--- a/src/dehydrated_devices.rs
+++ b/src/dehydrated_devices.rs
@@ -4,7 +4,7 @@
 
 use js_sys::{Array, JsString, Uint8Array};
 use matrix_sdk_crypto::{
-    dehydrated_devices, store::DehydratedDeviceKey as InnerDehydratedDeviceKey,
+    dehydrated_devices, store::types::DehydratedDeviceKey as InnerDehydratedDeviceKey,
 };
 use wasm_bindgen::prelude::*;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,6 +26,9 @@ pub enum DecryptionErrorCode {
     SenderIdentityVerificationViolation,
     /// Other failure.
     UnableToDecrypt,
+    /// The `sender` field on the event does not match the owner of the device
+    /// that established the Megolm session.
+    MismatchedSender,
 }
 
 /// Js Decryption error with code.
@@ -91,6 +94,9 @@ impl From<MegolmError> for MegolmDecryptionError {
                     // it as a generic UTD.
                     warn!("Unexpected verification level in megolm decryption error {}", value);
                     decryption_error(DecryptionErrorCode::UnableToDecrypt, None)
+                }
+                VerificationLevel::MismatchedSender => {
+                    decryption_error(DecryptionErrorCode::MismatchedSender, None)
                 }
             },
             _ => decryption_error(DecryptionErrorCode::UnableToDecrypt, None),

--- a/src/libolm_migration.rs
+++ b/src/libolm_migration.rs
@@ -22,7 +22,10 @@ use matrix_sdk_common::ruma::{
 };
 use matrix_sdk_crypto::{
     olm::PrivateCrossSigningIdentity,
-    store::{BackupDecryptionKey, Changes, DynCryptoStore, PendingChanges},
+    store::{
+        types::{BackupDecryptionKey, Changes, PendingChanges},
+        DynCryptoStore,
+    },
     types::{EventEncryptionAlgorithm, SigningKeys},
     vodozemac,
     vodozemac::{Curve25519PublicKey, Ed25519PublicKey},

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -17,7 +17,7 @@ use matrix_sdk_common::ruma::{
 use matrix_sdk_crypto::{
     backups::MegolmV1BackupKey,
     olm::{BackedUpRoomKey, ExportedRoomKey},
-    store::{DeviceChanges, IdentityChanges},
+    store::types::{DeviceChanges, IdentityChanges},
     types::RoomKeyBackupInfo,
     CryptoStoreError, EncryptionSyncChanges, GossippedSecret,
 };
@@ -632,7 +632,7 @@ impl OlmMachine {
         user_signing_key: Option<String>,
     ) -> Promise {
         let me = self.inner.clone();
-        let export = matrix_sdk_crypto::store::CrossSigningKeyExport {
+        let export = matrix_sdk_crypto::store::types::CrossSigningKeyExport {
             master_key,
             self_signing_key,
             user_signing_key,

--- a/src/store.rs
+++ b/src/store.rs
@@ -142,10 +142,10 @@ impl IntoCryptoStore for StoreHandle {
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct CrossSigningKeyExport {
-    pub(crate) inner: matrix_sdk_crypto::store::CrossSigningKeyExport,
+    pub(crate) inner: matrix_sdk_crypto::store::types::CrossSigningKeyExport,
 }
 
-impl_from_to_inner!(matrix_sdk_crypto::store::CrossSigningKeyExport => CrossSigningKeyExport);
+impl_from_to_inner!(matrix_sdk_crypto::store::types::CrossSigningKeyExport => CrossSigningKeyExport);
 
 #[wasm_bindgen]
 impl CrossSigningKeyExport {
@@ -172,10 +172,10 @@ impl CrossSigningKeyExport {
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct RoomKeyInfo {
-    pub(crate) inner: matrix_sdk_crypto::store::RoomKeyInfo,
+    pub(crate) inner: matrix_sdk_crypto::store::types::RoomKeyInfo,
 }
 
-impl_from_to_inner!(matrix_sdk_crypto::store::RoomKeyInfo => RoomKeyInfo);
+impl_from_to_inner!(matrix_sdk_crypto::store::types::RoomKeyInfo => RoomKeyInfo);
 
 #[wasm_bindgen]
 impl RoomKeyInfo {
@@ -209,10 +209,10 @@ impl RoomKeyInfo {
 #[wasm_bindgen]
 #[derive(Debug)]
 pub struct RoomKeyWithheldInfo {
-    pub(crate) inner: matrix_sdk_crypto::store::RoomKeyWithheldInfo,
+    pub(crate) inner: matrix_sdk_crypto::store::types::RoomKeyWithheldInfo,
 }
 
-impl_from_to_inner!(matrix_sdk_crypto::store::RoomKeyWithheldInfo => RoomKeyWithheldInfo);
+impl_from_to_inner!(matrix_sdk_crypto::store::types::RoomKeyWithheldInfo => RoomKeyWithheldInfo);
 
 #[wasm_bindgen]
 impl RoomKeyWithheldInfo {

--- a/src/types.rs
+++ b/src/types.rs
@@ -335,8 +335,8 @@ impl Default for RoomSettings {
     }
 }
 
-impl From<matrix_sdk_crypto::store::RoomSettings> for RoomSettings {
-    fn from(value: matrix_sdk_crypto::store::RoomSettings) -> Self {
+impl From<matrix_sdk_crypto::store::types::RoomSettings> for RoomSettings {
+    fn from(value: matrix_sdk_crypto::store::types::RoomSettings) -> Self {
         Self {
             algorithm: value.algorithm.into(),
             only_allow_trusted_devices: value.only_allow_trusted_devices,
@@ -350,7 +350,7 @@ impl From<matrix_sdk_crypto::store::RoomSettings> for RoomSettings {
     }
 }
 
-impl From<&RoomSettings> for matrix_sdk_crypto::store::RoomSettings {
+impl From<&RoomSettings> for matrix_sdk_crypto::store::types::RoomSettings {
     fn from(value: &RoomSettings) -> Self {
         Self {
             algorithm: value.algorithm.clone().into(),


### PR DESCRIPTION
Update the SDK to  https://github.com/matrix-org/matrix-rust-sdk/commit/6ab11a032, which includes matrix-org/matrix-rust-sdk#5219, which adds a new `VerificationLevel` for mismatched senders. We expose this to the application via a new `DecryptionErrorCode`.