### PR TITLE
feat: Add experimental encrypted state event support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UNRELEASED
 
+- Add support for experimental encrypted state events, introduce `EncryptionSettings::encrypt_state_events`,
+  `RoomSettings::encrypt_state_events`, and `OlmMachine::encrypt_state_event`.
+  ([#260](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/260/files))
+
 # matrix-sdk-crypto-wasm v15.2.0
 
 -   Update matrix-rust-sdk to 0.14.0, which includes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # UNRELEASED
 
-- **BREAKING** Add support for experimental encrypted state events, introduce
-  `EncryptionSettings::encrypt_state_events`, `RoomSettings::encrypt_state_events`,
-  and `OlmMachine::encrypt_state_event`.
-  ([#260](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/260/files))
+-   **BREAKING** Add support for experimental encrypted state events, introduce
+    `EncryptionSettings::encrypt_state_events`, `RoomSettings::encrypt_state_events`,
+    and `OlmMachine::encrypt_state_event`.
+    ([#260](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/260/files))
 
 # matrix-sdk-crypto-wasm v15.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # UNRELEASED
 
--   **BREAKING** Add support for experimental encrypted state events, introduce
-    `EncryptionSettings::encrypt_state_events`, `RoomSettings::encrypt_state_events`,
-    and `OlmMachine::encrypt_state_event`.
+-   Add support for experimental encrypted state events, introduce
+    `EncryptionSettings:.encryptStateEvents`, `RoomSettings.encryptStateEvents`,
+    and `OlmMachine.encryptStateEvent`.
     ([#260](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/260/files))
 
 # matrix-sdk-crypto-wasm v15.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # UNRELEASED
 
-- Add support for experimental encrypted state events, introduce `EncryptionSettings::encrypt_state_events`,
-  `RoomSettings::encrypt_state_events`, and `OlmMachine::encrypt_state_event`.
+- **BREAKING** Add support for experimental encrypted state events, introduce
+  `EncryptionSettings::encrypt_state_events`, `RoomSettings::encrypt_state_events`,
+  and `OlmMachine::encrypt_state_event`.
   ([#260](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/260/files))
 
 # matrix-sdk-crypto-wasm v15.2.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,7 +1198,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#4e2655aa1bd56469930f3ce11a57f08ac6f716aa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#3ba31d1e974dc364eea555b734c0dcac5a5d8588"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -1221,7 +1221,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#4e2655aa1bd56469930f3ce11a57f08ac6f716aa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#3ba31d1e974dc364eea555b734c0dcac5a5d8588"
 dependencies = [
  "aes",
  "aquamarine",
@@ -1289,7 +1289,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#4e2655aa1bd56469930f3ce11a57f08ac6f716aa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#3ba31d1e974dc364eea555b734c0dcac5a5d8588"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#4e2655aa1bd56469930f3ce11a57f08ac6f716aa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#3ba31d1e974dc364eea555b734c0dcac5a5d8588"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1329,7 +1329,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.13.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#4e2655aa1bd56469930f3ce11a57f08ac6f716aa"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#3ba31d1e974dc364eea555b734c0dcac5a5d8588"
 dependencies = [
  "base64",
  "blake3",
@@ -1814,7 +1814,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.12.6"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "assign",
  "js_int",
@@ -1829,7 +1829,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.20.4"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "assign",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.15.4"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "base64",
@@ -1885,7 +1885,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.30.5"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.4.1"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -1920,7 +1920,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.10.1"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "js_int",
  "thiserror 2.0.12",
@@ -1929,7 +1929,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.15.2"
-source = "git+https://github.com/ruma/ruma?rev=e85e224cef32181029efa106a059d277ecfbe87d#e85e224cef32181029efa106a059d277ecfbe87d"
+source = "git+https://github.com/ruma/ruma?rev=57049282e3a74f67f86e4eb2382a3e649b57cc2b#57049282e3a74f67f86e4eb2382a3e649b57cc2b"
 dependencies = [
  "cfg-if",
  "proc-macro-crate",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,13 @@ crate-type = ["cdylib"]
 default = ["qrcode"]
 qrcode = ["matrix-sdk-crypto/qrcode", "dep:matrix-sdk-qrcode"]
 
+# Enable experimental support for encrypting state events; see
+# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
+experimental-encrypted-state-events = [
+    "matrix-sdk-common/experimental-encrypted-state-events",
+    "matrix-sdk-crypto/experimental-encrypted-state-events"
+]
+
 [dependencies]
 console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,13 +57,6 @@ crate-type = ["cdylib"]
 default = ["qrcode"]
 qrcode = ["matrix-sdk-crypto/qrcode", "dep:matrix-sdk-qrcode"]
 
-# Enable experimental support for encrypting state events; see
-# https://github.com/matrix-org/matrix-rust-sdk/issues/5397.
-experimental-encrypted-state-events = [
-    "matrix-sdk-common/experimental-encrypted-state-events",
-    "matrix-sdk-crypto/experimental-encrypted-state-events"
-]
-
 [dependencies]
 console_error_panic_hook = "0.1.7"
 futures-util = "0.3.27"
@@ -71,7 +64,7 @@ futures-util = "0.3.27"
 getrandom = { version = "0.3.0", features = ["wasm_js"] }
 http = "1.1.0"
 js-sys = "0.3.49"
-matrix-sdk-common = { features = ["js"] , git = "https://github.com/matrix-org/matrix-rust-sdk" }
+matrix-sdk-common = { features = ["js", "experimental-encrypted-state-events"] , git = "https://github.com/matrix-org/matrix-rust-sdk" }
 matrix-sdk-indexeddb = { default-features = false, features = ["e2e-encryption"] , git = "https://github.com/matrix-org/matrix-rust-sdk" }
 matrix-sdk-qrcode = { optional = true , git = "https://github.com/matrix-org/matrix-rust-sdk" }
 serde = "1.0.91"
@@ -91,7 +84,7 @@ vergen-gitcl = { version = "1.0.0", features = ["build"] }
 
 [dependencies.matrix-sdk-crypto]
 default-features = false
-features = ["js", "automatic-room-key-forwarding"]
+features = ["js", "automatic-room-key-forwarding", "experimental-encrypted-state-events"]
 git = "https://github.com/matrix-org/matrix-rust-sdk"
 
 [lints.rust]

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -19,7 +19,6 @@ pub struct EncryptionSettings {
     pub algorithm: EncryptionAlgorithm,
 
     /// Whether state event encryption is enabled.
-    #[cfg(feature = "experimental-encrypted-state-events")]
     #[wasm_bindgen(js_name = "encryptStateEvents")]
     pub encrypt_state_events: bool,
 
@@ -49,7 +48,6 @@ impl Default for EncryptionSettings {
 
         Self {
             algorithm: default.algorithm.into(),
-            #[cfg(feature = "experimental-encrypted-state-events")]
             encrypt_state_events: default.encrypt_state_events,
             rotation_period: default.rotation_period.as_micros().try_into().unwrap(),
             rotation_period_messages: default.rotation_period_msgs,
@@ -74,7 +72,6 @@ impl From<&EncryptionSettings> for matrix_sdk_crypto::olm::EncryptionSettings {
 
         Self {
             algorithm,
-            #[cfg(feature = "experimental-encrypted-state-events")]
             encrypt_state_events: value.encrypt_state_events,
             rotation_period: Duration::from_micros(value.rotation_period),
             rotation_period_msgs: value.rotation_period_messages,

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -18,6 +18,11 @@ pub struct EncryptionSettings {
     /// The encryption algorithm that should be used in the room.
     pub algorithm: EncryptionAlgorithm,
 
+    /// Whether state event encryption is enabled.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    #[wasm_bindgen(js_name = "encryptStateEvents")]
+    pub encrypt_state_events: bool,
+
     /// How long the session should be used before changing it,
     /// expressed in microseconds.
     #[wasm_bindgen(js_name = "rotationPeriod")]
@@ -44,6 +49,8 @@ impl Default for EncryptionSettings {
 
         Self {
             algorithm: default.algorithm.into(),
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            encrypt_state_events: default.encrypt_state_events,
             rotation_period: default.rotation_period.as_micros().try_into().unwrap(),
             rotation_period_messages: default.rotation_period_msgs,
             history_visibility: default.history_visibility.into(),
@@ -67,6 +74,8 @@ impl From<&EncryptionSettings> for matrix_sdk_crypto::olm::EncryptionSettings {
 
         Self {
             algorithm,
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            encrypt_state_events: value.encrypt_state_events,
             rotation_period: Duration::from_micros(value.rotation_period),
             rotation_period_msgs: value.rotation_period_messages,
             history_visibility: value.history_visibility.clone().into(),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -554,7 +554,6 @@ impl OlmMachine {
     /// # Panics
     ///
     /// Panics if a group session for the given room was not previously shared.
-    #[cfg(feature = "experimental-encrypted-state-events")]
     #[wasm_bindgen(js_name = "encryptStateEvent")]
     pub fn encrypt_state_event(
         &self,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -527,7 +527,33 @@ impl OlmMachine {
         }))
     }
 
-    /// Encrypt a state message for the given room.
+    /// Encrypt a state event for the given room.
+    ///
+    /// This method encrypts a state event for the specified room, using the
+    /// current group session. The event will be encrypted so that only
+    /// authorized room members can decrypt it.
+    ///
+    /// **Note**: A room key must have been shared with the group of users in
+    /// the room before calling this method. If not, this method will panic.
+    ///
+    /// The usual flow to encrypt a state event using this machine is identical
+    /// to that outlined for [`OlmMachine::encrypt_room_event`].
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room for which the state event should be
+    ///   encrypted.
+    /// * `event_type` - The type of the state event.
+    /// * `state_key` - The state key for the event.
+    /// * `content` - The plaintext JSON content of the event to encrypt.
+    ///
+    /// # Returns
+    ///
+    /// A `Promise` resolving to a JSON string containing the encrypted event.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a group session for the given room was not previously shared.
     #[cfg(feature = "experimental-encrypted-state-events")]
     #[wasm_bindgen(js_name = "encryptStateEvent")]
     pub fn encrypt_state_event(

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -527,6 +527,34 @@ impl OlmMachine {
         }))
     }
 
+    /// Encrypt a state message for the given room.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    #[wasm_bindgen(js_name = "encryptStateEvent")]
+    pub fn encrypt_state_event(
+        &self,
+        room_id: &identifiers::RoomId,
+        event_type: String,
+        state_key: String,
+        content: &str,
+    ) -> Result<Promise, JsError> {
+        let _guard = dispatcher::set_default(&self.tracing_subscriber);
+        let room_id = room_id.inner.clone();
+        let content = serde_json::from_str(content)?;
+        let me = self.inner.clone();
+
+        Ok(future_to_promise(async move {
+            Ok(serde_json::to_string(
+                &me.encrypt_state_event_raw(
+                    &room_id,
+                    event_type.as_ref(),
+                    state_key.as_ref(),
+                    &content,
+                )
+                .await?,
+            )?)
+        }))
+    }
+
     /// Decrypt an event from a room timeline.
     ///
     /// # Arguments

--- a/src/types.rs
+++ b/src/types.rs
@@ -303,7 +303,6 @@ pub struct RoomSettings {
     pub algorithm: EncryptionAlgorithm,
 
     /// Whether state event encryption is enabled.
-    #[cfg(feature = "experimental-encrypted-state-events")]
     #[wasm_bindgen(js_name = "encryptStateEvents")]
     pub encrypt_state_events: bool,
 
@@ -336,7 +335,6 @@ impl Default for RoomSettings {
     fn default() -> Self {
         Self {
             algorithm: EncryptionAlgorithm::MegolmV1AesSha2,
-            #[cfg(feature = "experimental-encrypted-state-events")]
             encrypt_state_events: false,
             only_allow_trusted_devices: false,
             session_rotation_period_ms: None,
@@ -349,7 +347,6 @@ impl From<matrix_sdk_crypto::store::types::RoomSettings> for RoomSettings {
     fn from(value: matrix_sdk_crypto::store::types::RoomSettings) -> Self {
         Self {
             algorithm: value.algorithm.into(),
-            #[cfg(feature = "experimental-encrypted-state-events")]
             encrypt_state_events: value.encrypt_state_events,
             only_allow_trusted_devices: value.only_allow_trusted_devices,
             session_rotation_period_ms: value
@@ -366,7 +363,6 @@ impl From<&RoomSettings> for matrix_sdk_crypto::store::types::RoomSettings {
     fn from(value: &RoomSettings) -> Self {
         Self {
             algorithm: value.algorithm.clone().into(),
-            #[cfg(feature = "experimental-encrypted-state-events")]
             encrypt_state_events: value.encrypt_state_events,
             only_allow_trusted_devices: value.only_allow_trusted_devices,
             session_rotation_period: value

--- a/src/types.rs
+++ b/src/types.rs
@@ -302,6 +302,11 @@ pub struct RoomSettings {
     /// Should be one of the members of {@link EncryptionAlgorithm}.
     pub algorithm: EncryptionAlgorithm,
 
+    /// Whether state event encryption is enabled.
+    #[cfg(feature = "experimental-encrypted-state-events")]
+    #[wasm_bindgen(js_name = "encryptStateEvents")]
+    pub encrypt_state_events: bool,
+
     /// Whether untrusted devices should receive room keys. If this is `false`,
     /// they will be excluded from the conversation.
     #[wasm_bindgen(js_name = "onlyAllowTrustedDevices")]
@@ -331,6 +336,8 @@ impl Default for RoomSettings {
     fn default() -> Self {
         Self {
             algorithm: EncryptionAlgorithm::MegolmV1AesSha2,
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            encrypt_state_events: false,
             only_allow_trusted_devices: false,
             session_rotation_period_ms: None,
             session_rotation_period_messages: None,
@@ -342,6 +349,8 @@ impl From<matrix_sdk_crypto::store::types::RoomSettings> for RoomSettings {
     fn from(value: matrix_sdk_crypto::store::types::RoomSettings) -> Self {
         Self {
             algorithm: value.algorithm.into(),
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            encrypt_state_events: value.encrypt_state_events,
             only_allow_trusted_devices: value.only_allow_trusted_devices,
             session_rotation_period_ms: value
                 .session_rotation_period
@@ -357,6 +366,8 @@ impl From<&RoomSettings> for matrix_sdk_crypto::store::types::RoomSettings {
     fn from(value: &RoomSettings) -> Self {
         Self {
             algorithm: value.algorithm.clone().into(),
+            #[cfg(feature = "experimental-encrypted-state-events")]
+            encrypt_state_events: value.encrypt_state_events,
             only_allow_trusted_devices: value.only_allow_trusted_devices,
             session_rotation_period: value
                 .session_rotation_period_ms

--- a/tests/encryption.test.ts
+++ b/tests/encryption.test.ts
@@ -17,6 +17,7 @@ describe(EncryptionSettings.name, () => {
         const es = new EncryptionSettings();
 
         expect(es.algorithm).toStrictEqual(EncryptionAlgorithm.MegolmV1AesSha2);
+        expect(es.encryptStateEvents).toStrictEqual(false);
         expect(es.rotationPeriod).toStrictEqual(604800000000n);
         expect(es.rotationPeriodMessages).toStrictEqual(100n);
         expect(es.historyVisibility).toStrictEqual(HistoryVisibility.Shared);


### PR DESCRIPTION
Introduces support for experimental state event encryption, mostly conforming to https://github.com/matrix-org/matrix-rust-sdk/issues/5397. Features are **NOT** locked behind any feature flags, but this should not cause issues as we use `Self::default()` in the marked constructor.

- Adds `OlmMachine.encryptStateEvent`;
- Adds `EncryptionSettings.encryptStateEvents`.
- Adds `RoomSettings.encryptStateEvents`
