### PR TITLE
Update matrix-sdk to 64b12e0b8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # UNRELEASED
 
+-   Update matrix-rust-sdk to `64b12e0b80`
+
+    -   Change the return type of X509Signer::validity_not_after to Duration to make it easier for downstream crates to implement.
+        ([#6904](https://github.com/matrix-org/matrix-rust-sdk/pull/6904))
+
+    -   Make X.509 signing an async operation, meaning that the experimental `RawX509Signer::sign` now returns a Future.
+        ([#6867](https://github.com/matrix-org/matrix-rust-sdk/pull/6867))
+
 -   Fix `UserIdentity` methods to correctly set up the logging framework while
     they are running.
     ([#340](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/340))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,9 +689,9 @@ dependencies = [
 
 [[package]]
 name = "eyeball-im"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4790c03df183c2b46665c1a58118c04fd3e3976ec2fe16a0aa00e00c9eea7754"
+checksum = "3cf0c52231b6a6c3e262e5d69cbb425506abcce15bdd4c235fbb0d2a62ff64a2"
 dependencies = [
  "futures-core",
  "imbl",
@@ -1077,16 +1083,18 @@ dependencies = [
 
 [[package]]
 name = "imbl"
-version = "6.1.0"
+version = "7.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
+checksum = "43ea8d4c37ee560727e824d62804183624d371e632019b0e9e3532bce64a33e5"
 dependencies = [
  "archery",
  "bitmaps",
+ "equivalent",
  "imbl-sized-chunks",
  "rand_core 0.9.5",
  "rand_xoshiro",
  "version_check",
+ "wide",
 ]
 
 [[package]]
@@ -1323,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-base"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#955837c4677cd7e92e79447169b69666c0debae6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#64b12e0b808969c284c94f0ea239f37d6746d6e2"
 dependencies = [
  "as_variant",
  "async-trait",
@@ -1349,7 +1357,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-common"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#955837c4677cd7e92e79447169b69666c0debae6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#64b12e0b808969c284c94f0ea239f37d6746d6e2"
 dependencies = [
  "eyeball-im",
  "futures-core",
@@ -1372,7 +1380,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-crypto"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#955837c4677cd7e92e79447169b69666c0debae6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#64b12e0b808969c284c94f0ea239f37d6746d6e2"
 dependencies = [
  "aes",
  "as_variant",
@@ -1447,7 +1455,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-indexeddb"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#955837c4677cd7e92e79447169b69666c0debae6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#64b12e0b808969c284c94f0ea239f37d6746d6e2"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -1479,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-qrcode"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#955837c4677cd7e92e79447169b69666c0debae6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#64b12e0b808969c284c94f0ea239f37d6746d6e2"
 dependencies = [
  "byteorder",
  "qrcode",
@@ -1491,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "matrix-sdk-store-encryption"
 version = "0.18.0"
-source = "git+https://github.com/matrix-org/matrix-rust-sdk#955837c4677cd7e92e79447169b69666c0debae6"
+source = "git+https://github.com/matrix-org/matrix-rust-sdk#64b12e0b808969c284c94f0ea239f37d6746d6e2"
 dependencies = [
  "base64 0.23.1",
  "blake3",
@@ -1937,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "ruma"
 version = "0.16.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "assign",
  "js_int",
@@ -1952,7 +1960,7 @@ dependencies = [
 [[package]]
 name = "ruma-client-api"
 version = "0.24.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "as_variant",
  "assign",
@@ -1974,7 +1982,7 @@ dependencies = [
 [[package]]
 name = "ruma-common"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "as_variant",
  "base64 0.22.1",
@@ -2007,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "ruma-events"
 version = "0.34.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "as_variant",
  "indexmap",
@@ -2027,7 +2035,7 @@ dependencies = [
 [[package]]
 name = "ruma-html"
 version = "0.8.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "as_variant",
  "html5ever",
@@ -2038,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "ruma-identifiers-validation"
 version = "0.12.1"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "js_int",
  "thiserror",
@@ -2047,7 +2055,7 @@ dependencies = [
 [[package]]
 name = "ruma-macros"
 version = "0.19.0"
-source = "git+https://github.com/ruma/ruma?rev=db24422e03aea7c7974230098fe9aeb5481cddc6#db24422e03aea7c7974230098fe9aeb5481cddc6"
+source = "git+https://github.com/ruma/ruma?rev=0908aaa9847093ecb32bc6edf0af525f726717fd#0908aaa9847093ecb32bc6edf0af525f726717fd"
 dependencies = [
  "as_variant",
  "cfg-if",
@@ -2056,7 +2064,7 @@ dependencies = [
  "quote",
  "ruma-identifiers-validation",
  "serde",
- "syn 2.0.119",
+ "syn 3.0.3",
  "toml",
 ]
 
@@ -2109,6 +2117,15 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "safe_arch"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b02de82ddbe1b636e6170c21be622223aea188ef2e139be0a5b219ec215323"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "same-file"
@@ -2777,7 +2794,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 [[package]]
 name = "vodozemac"
 version = "0.10.0"
-source = "git+https://github.com/matrix-org/vodozemac?rev=f978854#f978854fc9150d4147b95abb0681f5b82c99f6f2"
+source = "git+https://github.com/matrix-org/vodozemac/?rev=cfc4eee#cfc4eeebdf0953314144a6b709449b0434019ca2"
 dependencies = [
  "aes",
  "arrayvec",
@@ -2973,6 +2990,16 @@ dependencies = [
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce5da8ecb62bcd8ec8b7ea19f69a51275e91299be594ea5cc6ef7819e16cd03"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/src/responses.rs
+++ b/src/responses.rs
@@ -15,7 +15,7 @@ pub(crate) use matrix_sdk_common::ruma::api::client::{
 };
 use matrix_sdk_common::{
     deserialized_responses::AlgorithmInfo,
-    ruma::{self, api::IncomingResponse as RumaIncomingResponse},
+    ruma::{self, api::IncomingResponseExt},
 };
 use matrix_sdk_crypto::types::requests::AnyIncomingResponse;
 use thiserror::Error;
@@ -23,8 +23,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::{encryption, identifiers, requests::RequestType};
 
-pub(crate) fn response_from_string(body: &str) -> http::Result<http::Response<Vec<u8>>> {
-    http::Response::builder().status(200).body(body.as_bytes().to_vec())
+pub(crate) fn response_from_string(body: &str) -> http::Result<http::Response<&[u8]>> {
+    http::Response::builder().status(200).body(body.as_bytes())
 }
 
 /// Intermediate private type to store an incoming owned response,
@@ -81,7 +81,7 @@ impl From<KeysBackupResponse> for OwnedResponse {
     }
 }
 
-impl TryFrom<(RequestType, http::Response<Vec<u8>>)> for OwnedResponse {
+impl TryFrom<(RequestType, http::Response<&[u8]>)> for OwnedResponse {
     type Error = JsError;
 
     /// Convert an HTTP response object into the underlying ruma model of the
@@ -95,7 +95,7 @@ impl TryFrom<(RequestType, http::Response<Vec<u8>>)> for OwnedResponse {
     /// * `request_type` - the type of the request that got this response
     /// * `response` - the raw HTTP response
     fn try_from(
-        (request_type, response): (RequestType, http::Response<Vec<u8>>),
+        (request_type, response): (RequestType, http::Response<&[u8]>),
     ) -> Result<Self, Self::Error> {
         match request_type {
             RequestType::KeysUpload => {


### PR DESCRIPTION
Fixes https://github.com/matrix-org/matrix-sdk-crypto-wasm/issues/342

Ruma changes from https://github.com/ruma/ruma/pull/2547 :

* Move `try_from_http_response` out of `IncomingResponse` into `IncomingResponseExt` https://github.com/ruma/ruma/commit/a28ae64fb84599b48115a828487fe1a6f7685edf
* Require a `Response` with `&[u8]` instead of an `AsRef<[u8]>` in `try_from_http_response` https://github.com/ruma/ruma/commit/794d2b33cca22f45bd3c44872e6a175709cc739a