### PR TITLE
Add `receiveSyncChangesMsc4186` to `OlmMachine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # UNRELEASED
 
+-   Add `OlmMachine.receiveSyncChangesMsc4186`, for processing the encryption
+    state from a simplified sliding sync (MSC4186) response. It behaves like
+    `receiveSyncChanges`, except that a missing one-time key count means
+    "unchanged" rather than "zero keys on the server".
+    [#345](https://github.com/matrix-org/matrix-sdk-crypto-wasm/pull/345)
+
 # matrix-sdk-crypto-wasm v18.6.0
 
 -   Allow providing `rawX509Signer` and `rawX509Validity` to

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -463,6 +463,50 @@ impl OlmMachine {
         #[wasm_bindgen(unchecked_optional_param_type = "DecryptionSettings")]
         decryption_settings: Option<encryption::DecryptionSettings>,
     ) -> Result<Promise, JsError> {
+        self.receive_sync_changes_impl(
+            to_device_events,
+            changed_devices,
+            one_time_keys_counts,
+            unused_fallback_keys,
+            decryption_settings,
+            false,
+        )
+    }
+
+    #[wasm_bindgen(
+        js_name = "receiveSyncChangesMsc4186",
+        unchecked_return_type = "Promise<ProcessedToDeviceEvent[]>"
+    )]
+    pub fn receive_sync_changes_msc4186(
+        &self,
+        to_device_events: &str,
+        changed_devices: &sync_events::DeviceLists,
+        #[wasm_bindgen(unchecked_param_type = "Map<string, number>")] one_time_keys_counts: &Map,
+        #[wasm_bindgen(unchecked_optional_param_type = "Set<string>")] unused_fallback_keys: Option<
+            Set,
+        >,
+        #[wasm_bindgen(unchecked_optional_param_type = "DecryptionSettings")]
+        decryption_settings: Option<encryption::DecryptionSettings>,
+    ) -> Result<Promise, JsError> {
+        self.receive_sync_changes_impl(
+            to_device_events,
+            changed_devices,
+            one_time_keys_counts,
+            unused_fallback_keys,
+            decryption_settings,
+            true,
+        )
+    }
+
+    fn receive_sync_changes_impl(
+        &self,
+        to_device_events: &str,
+        changed_devices: &sync_events::DeviceLists,
+        one_time_keys_counts: &Map,
+        unused_fallback_keys: Option<Set>,
+        decryption_settings: Option<encryption::DecryptionSettings>,
+        use_msc4186: bool,
+    ) -> Result<Promise, JsError> {
         let _guard = dispatcher::set_default(&self.tracing_subscriber);
         let to_device_events = serde_json::from_str(to_device_events)?;
         let changed_devices = changed_devices.inner.clone();
@@ -502,20 +546,21 @@ impl OlmMachine {
             // we discard the list of updated room keys in the result; JS applications are
             // expected to use register_room_key_updated_callback to receive updated room
             // keys.
-            let (processed_to_device_events, _) = me
-                .receive_sync_changes(
-                    EncryptionSyncChanges {
-                        to_device_events,
-                        changed_devices: &changed_devices,
-                        one_time_keys_counts: &one_time_keys_counts,
-                        unused_fallback_keys: unused_fallback_keys.as_deref(),
+            let sync_changes = EncryptionSyncChanges {
+                to_device_events,
+                changed_devices: &changed_devices,
+                one_time_keys_counts: &one_time_keys_counts,
+                unused_fallback_keys: unused_fallback_keys.as_deref(),
 
-                        // matrix-sdk-crypto does not (currently) use `next_batch_token`.
-                        next_batch_token: None,
-                    },
-                    &decryption_settings,
-                )
-                .await?;
+                // matrix-sdk-crypto does not (currently) use `next_batch_token`.
+                next_batch_token: None,
+            };
+
+            let (processed_to_device_events, _) = if use_msc4186 {
+                me.receive_sync_changes_msc4186(sync_changes, &decryption_settings).await?
+            } else {
+                me.receive_sync_changes(sync_changes, &decryption_settings).await?
+            };
 
             Ok(processed_to_device_events
                 .into_iter()

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -433,7 +433,11 @@ impl OlmMachine {
     ///   `/sync` response
     /// * `one_time_keys_counts`: The number of one-time keys on the server,
     ///   from the `/sync` response. A `Map` from string (encryption algorithm)
-    ///   to number (number of keys).
+    ///   to number (number of keys). Following the sync v2 semantics, a missing
+    ///   entry for an algorithm means that there are *zero* keys of that type
+    ///   on the server. If the caller has no information about the key counts
+    ///   (for example, because it is processing only part of a sync response),
+    ///   it should use {@link receiveSyncChangesMsc4186} instead.
     /// * `unused_fallback_keys`: Optionally, a `Set` of unused fallback keys on
     ///   the server, from the `/sync` response. If this is set, it is used to
     ///   determine if new fallback keys should be uploaded.
@@ -473,6 +477,43 @@ impl OlmMachine {
         )
     }
 
+    /// Handle the changes to the end-to-end encryption state we received from
+    /// a [MSC4186](https://github.com/matrix-org/matrix-spec-proposals/pull/4186)
+    /// (simplified sliding sync) response.
+    ///
+    /// This behaves exactly like {@link receiveSyncChanges}, except for the
+    /// handling of `one_time_keys_counts`: under MSC4186 semantics, a missing
+    /// entry for an algorithm means that the number of keys on the server is
+    /// *unchanged*, rather than zero.
+    ///
+    /// This is therefore also the method to use when the caller has no
+    /// information about the one-time key counts, for example because it is
+    /// processing only the to-device events or the device list changes from a
+    /// sync response.
+    ///
+    /// # Arguments
+    ///
+    /// * `to_device_events`: the JSON-encoded to-device events from the sync
+    ///   response
+    /// * `changed_devices`: the mapping of changed and left devices, from the
+    ///   sync response
+    /// * `one_time_keys_counts`: The number of one-time keys on the server,
+    ///   from the sync response. A `Map` from string (encryption algorithm) to
+    ///   number (number of keys). A missing entry means "unchanged".
+    /// * `unused_fallback_keys`: Optionally, a `Set` of unused fallback keys on
+    ///   the server, from the sync response. If this is set, it is used to
+    ///   determine if new fallback keys should be uploaded.
+    /// * `decryption_settings`: Optionally, the settings to use when decrypting
+    ///   to-device events. If not set, to-device events will be decrypted with
+    ///   a {@link TrustRequirement} of `Untrusted`.
+    ///
+    /// # Returns
+    ///
+    /// A list of values, each of which can be any of:
+    ///   * {@link DecryptedToDeviceEvent}
+    ///   * {@link PlainTextToDeviceEvent}
+    ///   * {@link UTDToDeviceEvent}
+    ///   * {@link InvalidToDeviceEvent}
     #[wasm_bindgen(
         js_name = "receiveSyncChangesMsc4186",
         unchecked_return_type = "Promise<ProcessedToDeviceEvent[]>"
@@ -498,6 +539,12 @@ impl OlmMachine {
         )
     }
 
+    /// Shared implementation of [`Self::receive_sync_changes`] and
+    /// [`Self::receive_sync_changes_msc4186`].
+    ///
+    /// `use_msc4186` selects the semantics of a missing entry in
+    /// `one_time_keys_counts`: `false` for sync v2 (missing means zero keys on
+    /// the server), `true` for MSC4186 (missing means unchanged).
     fn receive_sync_changes_impl(
         &self,
         to_device_events: &str,

--- a/tests/machine.test.ts
+++ b/tests/machine.test.ts
@@ -440,6 +440,41 @@ eXmIj7ZEOIsufPdiYuKDp/aUdgUHmuCGyegfoCJze36SdFX5q6z8Aq5nKPtz+FM=
         expect(receiveSyncChanges).toEqual([]);
     });
 
+    test("receiveSyncChangesMsc4186 treats a missing one-time key count as unchanged", async () => {
+        const m = await machine();
+        const noToDeviceEvents = JSON.stringify([]);
+        const noChangedDevices = new DeviceLists();
+
+        /** The number of one-time keys in the pending `KeysUploadRequest`, if any. */
+        const pendingOneTimeKeyUploads = async (): Promise<number> => {
+            const requests = await m.outgoingRequests();
+            const upload = requests.find((request) => request instanceof KeysUploadRequest);
+            return upload ? Object.keys(JSON.parse(upload.body).one_time_keys ?? {}).length : 0;
+        };
+
+        // Tell the machine that the server already holds plenty of one-time keys, and flush the initial device
+        // keys upload, so that nothing is pending.
+        await m.receiveSyncChanges(noToDeviceEvents, noChangedDevices, new Map([["signed_curve25519", 100]]));
+        for (const request of await m.outgoingRequests()) {
+            if (request instanceof KeysUploadRequest) {
+                await m.markRequestAsSent(
+                    request.id,
+                    request.type,
+                    JSON.stringify({ one_time_key_counts: { signed_curve25519: 100 } }),
+                );
+            }
+        }
+        expect(await pendingOneTimeKeyUploads()).toBe(0);
+
+        // Under MSC4186 semantics, a missing count means "unchanged": no new keys should be generated.
+        await m.receiveSyncChangesMsc4186(noToDeviceEvents, noChangedDevices, new Map());
+        expect(await pendingOneTimeKeyUploads()).toBe(0);
+
+        // Whereas under sync v2 semantics, a missing count means "zero keys on the server".
+        await m.receiveSyncChanges(noToDeviceEvents, noChangedDevices, new Map());
+        expect(await pendingOneTimeKeyUploads()).toBeGreaterThan(0);
+    });
+
     test("can get the outgoing requests that need to be sent out", async () => {
         const m = await machine();
         const toDeviceEvents = JSON.stringify([]);


### PR DESCRIPTION
Added `OlmMachine.receiveSyncChangesMsc4186`, which processes encryption state updates from MSC4186-style sync responses. Mirrors the changes made in https://github.com/matrix-org/matrix-rust-sdk/pull/6780.

Will be used to fix https://github.com/matrix-org/matrix-js-sdk/issues/5501 properly in https://github.com/matrix-org/matrix-js-sdk/pull/5503